### PR TITLE
Make pyproject.toml PEP621 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     {name = "Prashant Sinha", email = "prashant@noop.pw"},
     {name = "David Stromberger", email = "cavoq@proton.me"}
 ]
-license = "MIT"
+license = {text = "MIT"}
 requires-python = ">=3.5, <4"
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Makes `pyproject.toml` PEP621 compliant 